### PR TITLE
add missing function pointer for wrap_destroy to myfs_oper struct

### DIFF
--- a/src/mount.myfs.c
+++ b/src/mount.myfs.c
@@ -102,6 +102,7 @@ int main(int argc, char *argv[]) {
     myfs_oper.fsyncdir = wrap_fsyncdir;
     myfs_oper.init = wrap_init;
     myfs_oper.ftruncate = wrap_ftruncate;
+    myfs_oper.destroy = wrap_destroy;
 
     char* containerFileName= NULL;
     char* logFileName= NULL;


### PR DESCRIPTION
Solves the problem that the clean up code in `fuseDestroy` methods never gets called