### PR TITLE
add wrap_destroy to myfs_oper, mark MyFS destructor as virtual

### DIFF
--- a/includes/myfs.h
+++ b/includes/myfs.h
@@ -28,7 +28,7 @@ public:
     // TODO: [PART 2] You may add attributes of your file system here
     
     MyFS();
-    ~MyFS();
+    virtual ~MyFS();
     
     // --- Methods called by FUSE ---
     // For Documentation see https://libfuse.github.io/doxygen/structfuse__operations.html

--- a/src/mount.myfs.c
+++ b/src/mount.myfs.c
@@ -102,6 +102,7 @@ int main(int argc, char *argv[]) {
     myfs_oper.fsyncdir = wrap_fsyncdir;
     myfs_oper.init = wrap_init;
     myfs_oper.ftruncate = wrap_ftruncate;
+    myfs_oper.destroy = wrap_destroy;
 
     char* containerFileName= NULL;
     char* logFileName= NULL;


### PR DESCRIPTION
fuseDestroy currently never gets called because wrap_destroy is not passed to fused. Also the destructor of MyFS is not marked as virtual.